### PR TITLE
Reapply patches to wolfssl sources

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5368,6 +5368,7 @@ static int ProcessBufferTryDecode(WOLFSSL_CTX* ctx, WOLFSSL* ssl, DerBuffer* der
     return ret;
 }
 
+#define WOLFSSL_SMALL_STACK
 /* process the buffer buff, length sz, into ctx of format and type
    used tracks bytes consumed, userChain specifies a user cert chain
    to pass during the handshake */
@@ -5936,6 +5937,7 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
 
     return WOLFSSL_SUCCESS;
 }
+#undef WOLFSSL_SMALL_STACK
 
 
 /* CA PEM file for verification, may have multiple/chain certs to process */

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -89,11 +89,13 @@ uint64_t  wc_esp32elapsedTime();
 
 /* RAW hash function APIs are not implemented with esp32 hardware acceleration*/
 #define WOLFSSL_NO_HASH_RAW
+#define SHA_CTX DUMMY
 #if ESP_IDF_VERSION_MAJOR >= 4
 #include "esp32/rom/sha.h"
 #else
 #include "rom/sha.h"
 #endif
+#undef SHA_CTX
 
 typedef enum {
     ESP32_SHA_INIT = 0,


### PR DESCRIPTION
Author: Stephen Casner <casner@acm.org>
Date:   Tue Mar 9 22:16:57 2021 -0800

Previously in commit openvehicles/Open-Vehicle-Monitoring-System-3@04fafb83a3cc5563a5feb70a4bb7922457d58893:

To avoid a conflict between the definition of SHA_CTX in <openssl/ssl.h> and in esp-idf/include/esp32/rom/sha.h we add #define SHA_CTX DUMMY before reading the latter file to squelch its definition that we don't need.

Previously in commit openvehicles/Open-Vehicle-Monitoring-System-3@51444539047daef7bd2accb23ef40d1bc14fdb20:

We don't want to turn on WOLFSSL_SMALL_STACK globally because it slows down cyptography processing too much with allocations in PSRAM.  Just define that macro around ProcessBuffer() to reduce stack allocations in that function.
