### PR TITLE
ESP-IDFv5 : change included headers

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26091,7 +26091,7 @@ int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
     if (nameSz > 0)
         XMEMCPY(pParam->hostName, name, nameSz);
 
-        pParam->hostName[nameSz] = '\0';
+    pParam->hostName[nameSz] = '\0';
 
     return WOLFSSL_SUCCESS;
 }

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -37,8 +37,15 @@
 #include <freertos/FreeRTOS.h>
 #include "soc/dport_reg.h"
 #include "soc/hwcrypto_reg.h"
-#include "soc/cpu.h"
-#include "driver/periph_ctrl.h"
+
+#if ESP_IDF_VERSION_MAJOR >= 5
+    #include "esp_cpu.h"
+    #include "esp_private/periph_ctrl.h"
+#else
+    #include "soc/cpu.h"
+    #include "driver/periph_ctrl.h"
+#endif
+
 #if ESP_IDF_VERSION_MAJOR >= 4
 #include <esp32/rom/ets_sys.h>
 #else


### PR DESCRIPTION
Cf https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32/migration-guides/release-5.x/system.html#esp-hw-support

> The header files soc/cpu.h have been deleted and deprecated CPU util functions have been removed. ESP-IDF developers should include esp_cpu.h instead for equivalent functions.

Cf https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32/migration-guides/release-5.x/peripherals.html#peripheral-clock-gating

> ...the previous clock gating include path has been changed from driver/periph_ctrl.h to esp_private/periph_ctrl.h.


Fix for stricter compilation errors
```
/__w/Open-Vehicle-Monitoring-System-3/Open-Vehicle-Monitoring-System-3/vehicle/OVMS.V3/components/wolfssl/wolfssl/src/ssl.c: In function 'wolfSSL_X509_VERIFY_PARAM_set1_host':
/__w/Open-Vehicle-Monitoring-System-3/Open-Vehicle-Monitoring-System-3/vehicle/OVMS.V3/components/wolfssl/wolfssl/src/ssl.c:26093:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
26093 |     if (nameSz > 0)
      |     ^~
/__w/Open-Vehicle-Monitoring-System-3/Open-Vehicle-Monitoring-System-3/vehicle/OVMS.V3/components/wolfssl/wolfssl/src/ssl.c:26096:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
26096 |         pParam->hostName[nameSz] = '\0';
      |         ^~~~~~
cc1: some warnings being treated as errors
```